### PR TITLE
Fix semi-transparent component block

### DIFF
--- a/TcpBridge/mod/components/component.succ
+++ b/TcpBridge/mod/components/component.succ
@@ -16,8 +16,8 @@ TcpBridge:
                 mesh: BufferBody_Long
                 color: c9af38
                 position: (3.25, 1, 0) # 1.25+2
-                scale: (2, -1.1, 1)
-                rotation: (0,0,90)
+                scale: (2, 1.1, 1)
+                rotation: (0,0,270)
         inputs:
             - # data_in x8
                 position: (0, 1.5, -0.5) # -2+2

--- a/TcpBridge/mod/manifest.succ
+++ b/TcpBridge/mod/manifest.succ
@@ -1,5 +1,5 @@
 ID: ghxx.tcpbridge
 Name: Tcp Bridge
 Author: GHXX
-Version: 1.0.0
+Version: 1.0.1
 Priority: 10


### PR DESCRIPTION
One of the 3 blocks that the component consist of had a negative scale value. This does not seem to be supported in 0.91 anymore. Simply rotating the component instead of mirroring solves the issue.